### PR TITLE
Reference index.d.ts types in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,5 +34,6 @@
   "bugs": {
     "url": "https://github.com/jf3096/json-typescript-mapper/issues"
   },
-  "homepage": "https://github.com/jf3096/json-typescript-mapper#readme"
+  "homepage": "https://github.com/jf3096/json-typescript-mapper#readme",
+  "types": "index.d.ts"
 }


### PR DESCRIPTION
As recommended in http://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html,
the `package.json` should contain a reference to the type declarations file `index.d.ts`.

In addition to being best practice, it avoids some potential problems:

Without this reference, someone could have a project with the following `tsconfig.json`: 
```
"compilerOptions": {
    "moduleResolution": "node",
    "strictNullChecks": true
  },
  "exclude": [
    "node_modules"
  ]
```
Currently, if any file in their project has `import { deserialize } from "json-typescript-mapper";`, then `json-typescript-mapper/index.ts` will not be excluded by `tsc`. Therefore, when compiling their project with `strictNullChecks: true`, `json-typescript-mapper/index.ts` will be be incorrectly checked by `tsc`, and generate the following errors:
```
node_modules/json-typescript-mapper/index.ts(133,48): error TS2345: Argument of type '(new () => {}) | undefined' is not assignable to parameter of type 'new () => {}'.
  Type 'undefined' is not assignable to type 'new () => {}'.
node_modules/json-typescript-mapper/index.ts(163,9): error TS2322: Type 'undefined' is not assignable to type 'T'.
node_modules/json-typescript-mapper/index.ts(170,9): error TS2322: Type 'undefined' is not assignable to type 'T'.
```

Adding the `index.d.ts` reference to `package.json` allows `tsc` to correctly ignore `json-typescript-mapper`.